### PR TITLE
Use up to date node-alpine images, not slim images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@
 
 
 # Build project
-FROM node:12 AS builder
+FROM node:15.5.1-alpine AS builder
 RUN set -x \
     # Add user
     && addgroup --gid 10001 app \
     && adduser --disabled-password \
         --gecos '' \
-        --gid 10001 \
+        --ingroup app \
         --home /app \
         --uid 10001 \
         app
@@ -26,19 +26,17 @@ RUN set -x \
 
 
 # Main image
-FROM node:12-slim
+FROM node:15.5.1-alpine
 RUN set -x \
     # Add user
     && addgroup --gid 10001 app \
     && adduser --disabled-password \
         --gecos '' \
-        --gid 10001 \
+        --ingroup app \
         --home /app \
         --uid 10001 \
         app
-RUN apt-get update && apt-get -y install \
-    git-core \
-    && rm -rf /var/lib/apt/lists/*
+
 USER app
 WORKDIR /app
 COPY --chown=app:app package*.json ./

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "cache": true
   },
   "engines": {
-    "node": "^12.16.3"
+    "node": "^15.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
This PR does two (related) things:
- It attempts to update the nodeJS version used in `send` to a more up-to-date one.
- It switches to `-alpine` images instead of `-slim`.

I may be wrong but as far as I can see `send` doesn't actually require the Debian images' tools, and the alpine images are significantly smaller.

Let me know if I'm missing something obvious.