### PR TITLE
index.js: Add "data:" as an allowed image source in CSP

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -38,7 +38,7 @@ module.exports = function(app) {
           "'self'",
           config.base_url.replace(/^https:\/\//, 'wss://')
         ],
-        imgSrc: ["'self'"],
+        imgSrc: ["'self'", "data:"],
         scriptSrc: [
           "'self'",
           function(req) {


### PR DESCRIPTION
The `Content-Security-Policy` header that is automatically generated by Send currently does not include `data:` as an allowed image source. This leads to an error in the browser console when uploading files because the spinning circle that should be displayed during the upload process is loaded via `data:` URLs.

```
Refused to load the image 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABPElEQVRYR+2TsUrDUBSGv3uz1MUh6eALaEBcBVcfQpeCDm6CclWcHPQB1IrPUBd9A10EnyGCUnAouIQI0kmb5kqsgdiakDYNLjdT4J7zny/fyRVM8jT9E4Q8lpYm6uOD9KQVPkZ9q40UbQhu2Z3/KBItihSN1PwA5PQ+gW7RC684nHvJm1EVQDKzC6KFsrezIEoBDFYwiMh/l/coe/UviFIAY61P62f26u5wz2QA6ZTT1zpWzQXtIvQysAliJgOui3Jm02flAYYnnfkLsmZtRD19lLEaD+UsJW3TB0iSL4I14DrDxA3KWY/PqgOI0y+DRSK8XxCaDlo02LcfqgeIJ5y/28gw+B5m6Tv9KbY4cDrVryD92c23BoIVlL0z/Vsw1l0cLa72HygAZwCMAWPAGDAGjAFjwBgwBv7dwBdvs18hh/In1gAAAABJRU5ErkJggg==' because it violates the following Content Security Policy directive: "img-src 'self'".
```

This pull request fixes this issue by adding `data:` as an allowed image source in Send's CSP generator.
