### PR TITLE
main.css: Use ::marker to avoid browser console warning

### DIFF
--- a/app/main.css
+++ b/app/main.css
@@ -118,7 +118,7 @@ details {
   overflow: hidden;
 }
 
-details > summary::-webkit-details-marker {
+details > summary::marker {
   display: none;
 }
 


### PR DESCRIPTION
This pull request fixes the following deprecation warning in Chrome:
```
[Deprecation] ::-webkit-details-marker pseudo element selector is deprecated. Please use ::marker instead. See https://chromestatus.com/feature/6730096436051968 for more details.
```

