### PR TITLE
Add detect_base_url config

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -130,6 +130,11 @@ const conf = convict({
     default: 'https://send.firefox.com',
     env: 'BASE_URL'
   },
+  detect_base_url: {
+    format: Boolean,
+    default: false,
+    env: 'DETECT_BASE_URL'
+  },
   file_dir: {
     format: 'String',
     default: `${tmpdir()}${path.sep}send-${randomBytes(4).toString('hex')}`,
@@ -206,4 +211,18 @@ const conf = convict({
 conf.validate({ allowed: 'strict' });
 
 const props = conf.getProperties();
-module.exports = props;
+
+const deriveBaseUrl = (req) => {
+  if (props.detect_base_url) {
+    const protocol = req.secure ? 'https://' : 'http://';
+
+    return `${protocol}${req.headers.host}`;
+  } else {
+    return props.base_url;
+  }
+};
+
+module.exports = {
+  ...props,
+  deriveBaseUrl,
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -36,9 +36,14 @@ module.exports = function(app) {
         defaultSrc: ["'self'"],
         connectSrc: [
           "'self'",
-          config.base_url.replace(/^https:\/\//, 'wss://')
+          function(req) {
+            const baseUrl = config.deriveBaseUrl(req);
+            const r = baseUrl.replace(/^http(s?):\/\//, 'ws$1://');
+            console.log([baseUrl, r]);
+            return r;
+          }
         ],
-        imgSrc: ["'self'", "data:"],
+        imgSrc: ["'self'", 'data:'],
         scriptSrc: [
           "'self'",
           function(req) {
@@ -51,10 +56,6 @@ module.exports = function(app) {
         reportUri: '/__cspreport__'
       }
     };
-
-    csp.directives.connectSrc.push(
-      config.base_url.replace(/^https:\/\//, 'wss://')
-    );
 
     app.use(helmet.contentSecurityPolicy(csp));
   }

--- a/server/state.js
+++ b/server/state.js
@@ -23,6 +23,7 @@ module.exports = async function(req) {
   if (config.survey_url) {
     prefs.surveyUrl = config.survey_url;
   }
+  const baseUrl = config.deriveBaseUrl(req);
   return {
     archive: {
       numFiles: 0
@@ -33,7 +34,7 @@ module.exports = async function(req) {
     title: 'Send',
     description:
       'Encrypt and send files with a link that automatically expires to ensure your important documents don’t stay online forever.',
-    baseUrl: config.base_url,
+    baseUrl,
     ui: {},
     storage: {
       files: []


### PR DESCRIPTION
This diff adds the detect_base_url config, controlled by the
DETECT_BASE_URL env variable. When set to true, the BASE_URL setting is
ignored, and the base_url is derived from the request protocol and host
header.

Test Plan: Started up a local instance in my homelab, running docker
node:15 image with a nginx reverse proxy. Configured nginx to use the
same backend with multiple hostnames on https. Opened in browser and
confirmed og:url meta tag uses correct url.