### PR TITLE
Block search engines with robots.txt to make it more difficult to for public instances to be abused

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -9,6 +9,7 @@ module.exports = function(app = choo({ hash: true })) {
   app.route('/unsupported/:reason', body(require('./ui/unsupported')));
   app.route('/error', body(require('./ui/error')));
   app.route('/blank', body(require('./ui/blank')));
+  app.route('/robots.txt', function() {return 'User-agent: * Disallow: /'});
   app.route('/oauth', function(state, emit) {
     emit('authenticate', state.query.code, state.query.state);
   });


### PR DESCRIPTION
Right now it's pretty easy to use Google/Bing/DuckDuckGo to find public unsecured Send instances.

This is a security hazard to the server owners, as I'm sure you know the original Mozilla was shut down due to malicious users using it to host malware/CSAM.

I propose limiting search engine access to make it harder to discover these instances, as this will greatly limit the abuse/DMCA violations that public hosters have to deal with.

Advanced users wanting to allow search engine indexing will no doubt be running a reverse proxy in front of Send, which they can use to override the `/robots.txt` URL and return whatever content they want. This edit just makes it so that the bare, unsecured Send backend limits search engine access by default.