### PR TITLE
Fix glitchy UI dropdown select for max downloads and expiration

### DIFF
--- a/app/ui/expiryOptions.js
+++ b/app/ui/expiryOptions.js
@@ -31,12 +31,12 @@ module.exports = function(state, emit) {
       counts,
       num => state.translate('downloadCount', { num }),
       value => {
-        const max = state.user.maxDownloads;
-        state.archive.dlimit = Math.min(value, max);
-        if (value > max) {
+        const selected = parseInt(value);
+        state.archive.dlimit = selected;
+        emit('render');
+        if (selected > parseInt(state.user.maxDownloads || '0')) {
+          console.log('Chosen max download count is larger than the allowed limit for anonymous users', selected)
           emit('signup-cta', 'count');
-        } else {
-          emit('render');
         }
       },
       'expire-after-dl-count-select'
@@ -58,12 +58,12 @@ module.exports = function(state, emit) {
         return state.translate(l10n.id, l10n);
       },
       value => {
-        const max = state.user.maxExpireSeconds;
-        state.archive.timeLimit = Math.min(value, max);
-        if (value > max) {
+        const selected = parseInt(value);
+        state.archive.timeLimit = selected;
+        emit('render');
+        if (selected > parseInt(state.user.maxExpireSeconds || '0')) {
+          console.log('Chosen download expiration is larger than the allowed limit for anonymous users', selected)
           emit('signup-cta', 'time');
-        } else {
-          emit('render');
         }
       },
       'expire-after-time-select'

--- a/app/ui/expiryOptions.js
+++ b/app/ui/expiryOptions.js
@@ -35,8 +35,7 @@ module.exports = function(state, emit) {
         state.archive.dlimit = selected;
         emit('render');
         if (selected > parseInt(state.user.maxDownloads || '0')) {
-          console.log('Chosen max download count is larger than the allowed limit for anonymous users', selected)
-          emit('signup-cta', 'count');
+          console.log('Chosen max download count is larger than the allowed limit', selected)
         }
       },
       'expire-after-dl-count-select'
@@ -62,8 +61,7 @@ module.exports = function(state, emit) {
         state.archive.timeLimit = selected;
         emit('render');
         if (selected > parseInt(state.user.maxExpireSeconds || '0')) {
-          console.log('Chosen download expiration is larger than the allowed limit for anonymous users', selected)
-          emit('signup-cta', 'time');
+          console.log('Chosen download expiration is larger than the allowed limit', selected)
         }
       },
       'expire-after-time-select'

--- a/app/ui/selectbox.js
+++ b/app/ui/selectbox.js
@@ -1,32 +1,28 @@
 const html = require('choo/html');
 
 module.exports = function(selected, options, translate, changed, htmlId) {
-  let x = selected;
-
+  function choose(event) {
+    if (event.target.value != selected) {
+      console.log('Selected new value from dropdown', htmlId, ':', selected, '->', event.target.value)
+      changed(event.target.value);
+    }
+  }
+  
   return html`
     <select
       id="${htmlId}"
       class="appearance-none cursor-pointer border rounded bg-grey-10 hover:border-blue-50 focus:border-blue-50 pl-1 pr-8 py-1 my-1 h-8 dark:bg-grey-80"
+      data-selected="${selected}"
       onchange="${choose}"
     >
       ${options.map(
-        i =>
+        value =>
           html`
-            <option value="${i}" ${i === selected ? 'selected' : ''}
-              >${translate(i)}</option
-            >
+            <option value="${value}" ${value == selected ? 'selected' : ''}>
+              ${translate(value)}
+            </option>
           `
       )}
     </select>
   `;
-
-  function choose(event) {
-    const target = event.target;
-    const value = +target.value;
-
-    if (x !== value) {
-      x = value;
-      changed(value);
-    }
-  }
 };

--- a/server/config.js
+++ b/server/config.js
@@ -5,15 +5,18 @@ const { randomBytes } = require('crypto');
 
 convict.addFormat({
   name: 'positive-int-array',
-  validate: (ints, schema) => {
+  coerce: (ints, schema) => {        // can take: int[] | string[] | string (csv), returns -> int[]
+      const ints_arr = Array.isArray(ints) ? ints : ints.trim().split(',')
+      return ints_arr.map(int =>
+        (typeof int === 'number')
+          ? int
+          : parseInt(int.trim(), 10))
+  },
+  validate: (ints, schema) => {      // takes: int[], errors if any NaNs, negatives, or floats present
     for (const int of ints) {
-      if (isNaN(int) || int < 0)
+      if (typeof(int) !== 'number' || isNaN(int) || int < 0 || int % 1 > 0)
         throw new Error('must be a comma-separated list of positive integers')
     }
-  },
-  coerce: (ints, schema) => {
-      const ints_arr = Array.isArray(ints_str) ? ints : ints.trim().split(',')
-      return ints_arr.map(int => (typeof int === 'number') ? int : parseInt(int.trim(), 10))
   },
 });
 

--- a/server/config.js
+++ b/server/config.js
@@ -6,13 +6,14 @@ const { randomBytes } = require('crypto');
 convict.addFormat({
   name: 'positive-int-array',
   validate: (ints, schema) => {
-    ints.forEach(int => {
-     if (isNaN(int) || int < 0)
+    for (const int of ints) {
+      if (isNaN(int) || int < 0)
         throw new Error('must be a comma-separated list of positive integers')
-    })
+    }
   },
-  coerce: (ints_str, schema) =>
-      ints_str.trim().split(',').map(int_str => parseInt(int_str.trim(), 10))
+  coerce: (ints_str, schema) => {
+      return ints_str.trim().split(',').map(int_str => parseInt(int_str.trim(), 10))
+  },
 });
 
 const conf = convict({

--- a/server/config.js
+++ b/server/config.js
@@ -11,8 +11,9 @@ convict.addFormat({
         throw new Error('must be a comma-separated list of positive integers')
     }
   },
-  coerce: (ints_str, schema) => {
-      return ints_str.trim().split(',').map(int_str => parseInt(int_str.trim(), 10))
+  coerce: (ints, schema) => {
+      const ints_arr = Array.isArray(ints_str) ? ints : ints.trim().split(',')
+      return ints_arr.map(int => (typeof int === 'number') ? int : parseInt(int.trim(), 10))
   },
 });
 

--- a/server/config.js
+++ b/server/config.js
@@ -3,6 +3,18 @@ const { tmpdir } = require('os');
 const path = require('path');
 const { randomBytes } = require('crypto');
 
+convict.addFormat({
+  name: 'positive-int-array',
+  validate: (ints, schema) => {
+    ints.forEach(int => {
+     if (isNaN(int) || int < 0)
+        throw new Error('must be a comma-separated list of positive integers')
+    })
+  },
+  coerce: (ints_str, schema) =>
+      ints_str.trim().split(',').map(int_str => parseInt(int_str.trim(), 10))
+});
+
 const conf = convict({
   s3_bucket: {
     format: String,
@@ -25,7 +37,7 @@ const conf = convict({
     env: 'GCS_BUCKET'
   },
   expire_times_seconds: {
-    format: Array,
+    format: 'positive-int-array',
     default: [300, 3600, 86400, 604800],
     env: 'EXPIRE_TIMES_SECONDS'
   },
@@ -40,7 +52,7 @@ const conf = convict({
     env: 'MAX_EXPIRE_SECONDS'
   },
   download_counts: {
-    format: Array,
+    format: 'positive-int-array',
     default: [1, 2, 3, 4, 5, 20, 50, 100],
     env: 'DOWNLOAD_COUNTS'
   },


### PR DESCRIPTION
Currently there is a bug with the UI selection dropdowns where config values `EXPIRE_TIMES_SECONDS` and `DOWNLOAD_COUNTS` loaded as string arrays fail the strict `if (existing val !== chosen val) set...` check in the dropdown onchange handler https://github.com/timvisee/send/pull/36/files#diff-a9e45594669203e5e550875e43529ae26c24aeffb9af1bb0ba333015f471447cL15-R23, causing this glitchy behavior:

<img src="https://user-images.githubusercontent.com/511499/118757841-dde0a380-b83b-11eb-9d5b-21c67194cae9.gif" width="500px" alt="bug screen recording"/>

There is no way to provide the `EXPIRE_TIMES_SECONDS` and `DOWNLOAD_COUNTS` config values as integer arrays with Docker, so this PR fixes the handling in the case that they are string arrays (as they always are when set via env vars). It also adds some logging to make it clearer in the console and from the HTML which item is selected and fixes a race condition between the form selection change and signup modal popup.

**PR Roadmap:**

- [x] record existing `master` behavior with default config value: `works as expected, dropdowns chose values and do not reset on change`
- [x] record existing `master` behavior with config values changed via env var to string array: `broken, dropdowns reset on change (see screen recording)`
- [x] confirm behavior of this PR using default/unset config values is correct: `TODO`
- [x] confirm behavior of this PR with config values changed via env var to string array is correct: `TODO`
- [x] confirm behavior of this PR is consistent across all major browsers (Chrome/Firefox/Safari): `TODO`
- [x] change from draft -> ready for review and get an approval from timvisee
- [x] merge and release 🎉 🚀 