### PR TITLE
Updated docs to include custom CSS and custom footer, and have added the ability to add a custom locale.

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -96,6 +96,11 @@ See the table below for the variables and their default values.
 | UI_CUSTOM_ASSETS_FACEBOOK | | A custom header image for Facebook |
 | UI_CUSTOM_ASSETS_TWITTER | | A custom header image for Twitter |
 | UI_CUSTOM_ASSETS_WORDMARK | | A custom wordmark (Text next to the logo) |
+| UI_CUSTOM_CSS | | Allows you to define a custom CSS file for custom styling |
+| CUSTOM_FOOTER_TEXT | | Allows you to define a custom footer |
+| CUSTOM_FOOTER_URL | | Allows you to define a custom URL in your footer |
+
+Side note: If you define a custom URL and a custom footer, only the footer text will display, but will be hyperlinked to the URL.
 
 ## Examples
 

--- a/server/config.js
+++ b/server/config.js
@@ -273,6 +273,11 @@ const conf = convict({
     default: '#003eaa',
     env: 'UI_COLOR_ACCENT'
   },
+  custom_locale: {
+    format: String,
+    default: '',
+    env: 'CUSTOM_LOCALE'
+  },
   ui_custom_assets: {
     android_chrome_192px: {
       format: String,

--- a/server/state.js
+++ b/server/state.js
@@ -3,9 +3,18 @@ const layout = require('./layout');
 const assets = require('../common/assets');
 const getTranslator = require('./locale');
 const { getFxaConfig } = require('./fxa');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = async function(req) {
-  const locale = req.language || 'en-US';
+  const locale = (() => {
+    if (config.custom_locale != '' && fs.existsSync(path.join(__dirname,'../public/locales',config.custom_locale))) {
+        return config.custom_locale;
+    }
+    else {
+      return req.language || 'en-US';
+    }
+  })();
   let authConfig = null;
   let robots = 'none';
   if (req.route && req.route.path === '/') {


### PR DESCRIPTION
Updated the docs to include custom CSS and custom footer.

Also added the ability to use a custom defined locale, overriding the default/visitor based behavior, to address issue #81 as follows:

New environment variable CUSTOM_LOCALE allows a user to define a locale per the /public/locales directory (this should be listed in the docs, will create a pull request for that too).

If the environment variable is blank or invalid it reverts to previous behavior of system + default locale. Fully tested the above as follows:

CUSTOM_LOCALE = 'nl' < This works correctly, translating to nl.
CUSTOM_LOCALE = 'HelloThere' < This reverts to previous behavior of system + default
CUSTOM_LOCALE = '' < Also reverts
#CUSTOM_LOCALE = < Also reverts

Haven't as yet updated the docs to include the CUSTOM_LOCALE, will do that in my next commit/pull request.