### PR TITLE
Increase password length limit to support passphrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ AWS example using Ubuntu Server `20.04`: [docs/AWS.md](docs/AWS.md)
 - Web: _this repository_
 - Command-line: [`ffsend`](https://github.com/timvisee/ffsend)
 - Android: _see [Android](#android) section_
-- Thunderbird: [FileLink provider for Send](https://addons.thunderbird.net/en-US/thunderbird/addon/filelink-provider-for-send/)
+- Thunderbird: [FileLink provider for Send](https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-send/)
 
 #### Android
 

--- a/app/ui/archiveTile.js
+++ b/app/ui/archiveTile.js
@@ -26,7 +26,7 @@ function expiryInfo(translate, archive) {
 }
 
 function password(state) {
-  const MAX_LENGTH = 32;
+  const MAX_LENGTH = 4096;
 
   return html`
     <div class="mb-2 px-1">

--- a/app/ui/downloadPassword.js
+++ b/app/ui/downloadPassword.js
@@ -32,7 +32,7 @@ module.exports = function(state, emit) {
           class="w-full border-l border-t border-b rounded-l-lg rounded-r-none ${invalid
             ? 'border-red dark:border-red-40'
             : 'border-grey'} leading-loose px-2 py-1 dark:bg-grey-80"
-          maxlength="32"
+          maxlength="4096"
           autocomplete="off"
           placeholder="${state.translate('unlockInputPlaceholder')}"
           oninput="${inputChanged}"


### PR DESCRIPTION
* Increased password length limit from 32 to 256 characters to support secure passphrases. Fixes https://github.com/mozilla/send/issues/1302
* Localized my ATN link on the README.

I noticed this limitation while testing https://github.com/tdulcet/Thunderbird-Send/issues/8. My add-on could upload files with longer passwords, but the web UI would then not allow users to download the files. 😨 If I used the browser devtools to remove the `maxlength` attribute, it would work as expected, so there does not seem to be a technical reason for this limitation. I would also be happy to completely remove the password length limit, if that would be OK with you.

This change should also allow you to revert https://github.com/timvisee/ffsend/commit/fdf8ae9201ec02afb17775b09e6dda3e9bf5c696.