### PR TITLE
fix: use Authorization header

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -43,7 +43,7 @@ function post(obj, bearerToken) {
     'Content-Type': 'application/json'
   };
   if (bearerToken) {
-    h['Authentication'] = `Bearer ${bearerToken}`;
+    h['Authorization'] = `Bearer ${bearerToken}`;
   }
   return {
     method: 'POST',


### PR DESCRIPTION
Corrects the HTTP header to use `Authorization` in the `POST` request helper.

---

* [Authorization request header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Authorization)
* [HTTP authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication)