### PR TITLE
Added Thunderbird add-on link to footer

### DIFF
--- a/app/ui/footer.js
+++ b/app/ui/footer.js
@@ -37,6 +37,15 @@ class Footer extends Component {
           </li>
         `);
       }
+      if (WEB_UI.FOOTER_THUNDERBIRD_ADDON_URL != '') {
+        links.push(html`
+          <li class="m-2">
+            <a href="${WEB_UI.FOOTER_THUNDERBIRD_ADDON_URL}" target="_blank">
+              ${translate('footerLinkThunderbirdAddon')}
+            </a>
+          </li>
+        `);
+      }
       if (WEB_UI.FOOTER_DMCA_URL != '') {
         links.push(html`
           <li class="m-2">

--- a/public/locales/en-US/send.ftl
+++ b/public/locales/en-US/send.ftl
@@ -29,6 +29,7 @@ deleteButtonHover = Delete
 footerText = Not affiliated with Mozilla or Firefox.
 footerLinkDonate = Donate
 footerLinkCli = CLI
+footerLinkThunderbirdAddon = Thunderbird Add-on
 footerLinkDmca = DMCA
 footerLinkSource = Source
 passwordTryAgain = Incorrect password. Try again.

--- a/server/clientConstants.js
+++ b/server/clientConstants.js
@@ -11,6 +11,7 @@ module.exports = {
   WEB_UI: {
     FOOTER_DONATE_URL: config.footer_donate_url,
     FOOTER_CLI_URL: config.footer_cli_url,
+    FOOTER_THUNDERBIRD_ADDON_URL: config.footer_thunderbird_addon_url,
     FOOTER_DMCA_URL: config.footer_dmca_url,
     FOOTER_SOURCE_URL: config.footer_source_url,
     CUSTOM_FOOTER_TEXT: config.custom_footer_text,

--- a/server/config.js
+++ b/server/config.js
@@ -244,6 +244,11 @@ const conf = convict({
     default: 'https://github.com/timvisee/ffsend',
     env: 'SEND_FOOTER_CLI_URL'
   },
+  footer_thunderbird_addon_url: {
+    format: String,
+    default: 'https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-send/',
+    env: 'SEND_FOOTER_THUNDERBIRD_ADDON_URL'
+  },
   footer_dmca_url: {
     format: String,
     default: '',


### PR DESCRIPTION
* Added link for the [FileLink provider for Send](https://addons.thunderbird.net/thunderbird/addon/filelink-provider-for-send/) Thunderbird add-on to footer

We could use just "Thunderbird" in the link text if "Thunderbird Add-on" were too long, or maybe use an emoji.