### PR TITLE
security: harden auth, dlimit enforcement, and crypto

### DIFF
--- a/app/keychain.js
+++ b/app/keychain.js
@@ -74,7 +74,7 @@ export default class Keychain {
           {
             name: 'PBKDF2',
             salt: encoder.encode(shareUrl),
-            iterations: 100,
+            iterations: 100000,
             hash: 'SHA-256'
           },
           passwordKey,

--- a/server/config.js
+++ b/server/config.js
@@ -199,6 +199,11 @@ const conf = convict({
     default: '', // disabled
     env: 'FXA_CLIENT_ID'
   },
+  fxa_required: {
+    format: Boolean,
+    default: false,
+    env: 'FXA_REQUIRED'
+  },
   fxa_key_scope: {
     format: String,
     default: 'https://identity.mozilla.com/apps/send',

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -23,7 +23,7 @@ module.exports = {
         const verifyHash = hmac.digest();
         if (crypto.timingSafeEqual(verifyHash, Buffer.from(auth, 'base64'))) {
           req.nonce = crypto.randomBytes(16).toString('base64');
-          storage.setField(id, 'nonce', req.nonce);
+          await storage.setField(id, 'nonce', req.nonce);
           res.set('WWW-Authenticate', `send-v1 ${req.nonce}`);
           req.authorized = true;
           req.meta = meta;

--- a/server/routes/download.js
+++ b/server/routes/download.js
@@ -4,8 +4,20 @@ const log = mozlog('send.download');
 
 module.exports = async function(req, res) {
   const id = req.params.id;
+  let claimed = false;
   try {
     const meta = req.meta;
+    const dlimit = meta.dlimit;
+    // Atomically claim a download slot before any work, so concurrent
+    // requests with the same Authorization header cannot exceed dlimit.
+    const newDl = await storage.incrementField(id, 'dl');
+    claimed = true;
+    if (newDl > dlimit) {
+      await storage.incrementField(id, 'dl', -1);
+      claimed = false;
+      return res.sendStatus(404);
+    }
+
     const contentLength = await storage.length(id);
     const fileStream = await storage.get(id);
     let cancelled = false;
@@ -19,24 +31,40 @@ module.exports = async function(req, res) {
       'Content-Type': 'application/octet-stream',
       'Content-Length': contentLength
     });
-    fileStream.pipe(res).on('finish', async () => {
-      if (cancelled) {
-        return;
-      }
-
-      const dl = meta.dl + 1;
-      const dlimit = meta.dlimit;
-      try {
-        if (dl >= dlimit) {
-          await storage.del(id);
-        } else {
-          await storage.incrementField(id, 'dl');
+    fileStream
+      .pipe(res)
+      .on('finish', async () => {
+        if (cancelled) {
+          try {
+            await storage.incrementField(id, 'dl', -1);
+          } catch (e) {
+            log.info('StorageError:', id);
+          }
+          return;
         }
-      } catch (e) {
+        try {
+          if (newDl >= dlimit) {
+            await storage.del(id);
+          }
+        } catch (e) {
+          log.info('StorageError:', id);
+        }
+      })
+      .on('error', async () => {
+        try {
+          await storage.incrementField(id, 'dl', -1);
+        } catch (e) {
+          log.info('StorageError:', id);
+        }
+      });
+  } catch (e) {
+    if (claimed) {
+      try {
+        await storage.incrementField(id, 'dl', -1);
+      } catch (err) {
         log.info('StorageError:', id);
       }
-    });
-  } catch (e) {
+    }
     res.sendStatus(404);
   }
 };

--- a/server/routes/params.js
+++ b/server/routes/params.js
@@ -4,7 +4,7 @@ const storage = require('../storage');
 module.exports = function(req, res) {
   const max = config.max_downloads;
   const dlimit = req.body.dlimit;
-  if (!dlimit || dlimit > max) {
+  if (!Number.isInteger(dlimit) || dlimit < 1 || dlimit > max) {
     return res.sendStatus(400);
   }
 

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -14,11 +14,19 @@ module.exports = async function(req, res) {
   if (!metadata || !auth) {
     return res.sendStatus(400);
   }
+  const authParts = auth.split(' ');
+  if (
+    authParts.length !== 2 ||
+    authParts[0] !== 'send-v1' ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(authParts[1])
+  ) {
+    return res.sendStatus(400);
+  }
   const owner = crypto.randomBytes(10).toString('hex');
   const meta = {
     owner,
     metadata,
-    auth: auth.split(' ')[1],
+    auth: authParts[1],
     nonce: crypto.randomBytes(16).toString('base64')
   };
 

--- a/server/routes/ws.js
+++ b/server/routes/ws.js
@@ -45,9 +45,26 @@ module.exports = function(ws, req) {
       if (
         !metadata ||
         !auth ||
+        !Number.isInteger(timeLimit) ||
         timeLimit <= 0 ||
         timeLimit > maxExpireSeconds ||
+        !Number.isInteger(dlimit) ||
+        dlimit < 1 ||
         dlimit > maxDownloads
+      ) {
+        ws.send(
+          JSON.stringify({
+            error: 400
+          })
+        );
+        return ws.close();
+      }
+
+      const authParts = typeof auth === 'string' ? auth.split(' ') : [];
+      if (
+        authParts.length !== 2 ||
+        authParts[0] !== 'send-v1' ||
+        !/^[A-Za-z0-9+/]+={0,2}$/.test(authParts[1])
       ) {
         ws.send(
           JSON.stringify({
@@ -61,7 +78,7 @@ module.exports = function(ws, req) {
         owner,
         metadata,
         dlimit,
-        auth: auth.split(' ')[1],
+        auth: authParts[1],
         nonce: crypto.randomBytes(16).toString('base64')
       };
 

--- a/server/storage/index.js
+++ b/server/storage/index.js
@@ -59,11 +59,11 @@ class DB {
   }
 
   setField(id, key, value) {
-    this.redis.hset(id, key, value);
+    return this.redis.hsetAsync(id, key, value);
   }
 
   incrementField(id, key, increment = 1) {
-    this.redis.hincrby(id, key, increment);
+    return this.redis.hincrbyAsync(id, key, increment);
   }
 
   async del(id) {

--- a/server/storage/redis.js
+++ b/server/storage/redis.js
@@ -32,6 +32,8 @@ module.exports = function(config) {
   client.ttlAsync = promisify(client.ttl);
   client.hgetallAsync = promisify(client.hgetall);
   client.hgetAsync = promisify(client.hget);
+  client.hsetAsync = promisify(client.hset);
+  client.hincrbyAsync = promisify(client.hincrby);
   client.pingAsync = promisify(client.ping);
   return client;
 };

--- a/server/storage/s3.js
+++ b/server/storage/s3.js
@@ -9,8 +9,7 @@ class S3Storage {
       cfg['endpoint'] = config.s3_endpoint;
     }
     cfg['s3ForcePathStyle'] = config.s3_use_path_style_endpoint;
-    AWS.config.update(cfg);
-    this.s3 = new AWS.S3();
+    this.s3 = new AWS.S3(cfg);
   }
 
   async length(id) {


### PR DESCRIPTION
- keychain: raise PBKDF2 iterations from 100 to 100000 for password protected file auth-key derivation
- config: declare fxa_required (FXA_REQUIRED) so the auth gate in middleware/auth.js and routes/ws.js is actually honored
- download: atomically claim a dl slot via HINCRBY before streaming so concurrent requests sharing an Authorization header cannot exceed dlimit; refund on cancel or error
- auth middleware: await nonce rotation write before responding
- upload + ws: reject Authorization headers that are not send-v1 <base64>, preventing a stored "undefined" auth key
- params + ws: require dlimit to be a positive integer <= max
- storage: make setField/incrementField return promises (promisified hset/hincrby) so callers can await
- s3 storage: pass endpoint/path-style config to new AWS.S3(cfg) instead of mutating global AWS.config